### PR TITLE
Bumping version number to work with pypi

### DIFF
--- a/donjuan/__init__.py
+++ b/donjuan/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 __docs__ = "Package for generating dungeons."
 
 from .cell import Cell, HexCell, SquareCell

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="Donjuan",
+    name="donjuan",
     author="Tom McClintock",
     author_email="thmsmcclintock@gmail.com",
     version=donjuan.__version__,

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,21 @@ from setuptools import setup
 
 import donjuan  # noqa: E402
 
+with open("README.rst", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name="Donjuan",
     author="Tom McClintock",
     author_email="thmsmcclintock@gmail.com",
     version=donjuan.__version__,
     description=donjuan.__docs__,
+    long_description=long_description,
     url="https://github.com/tmcclintock/PyDonJuan",
     packages=["donjuan"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
PyPI needs the version number to be bumped in order for the package to be able to be reuploaded.