### PR TITLE
Room class

### DIFF
--- a/donjuan/__init__.py
+++ b/donjuan/__init__.py
@@ -8,3 +8,4 @@ from .face import BareFace, DoorFace, Face, Faces, HexFaces, SquareFaces
 from .grid import Grid, HexGrid, SquareGrid
 from .randomizer import RandomFilled, Randomizer
 from .renderer import BaseRenderer, Renderer
+from .room import Room

--- a/donjuan/cell.py
+++ b/donjuan/cell.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from donjuan.door_space import DoorSpace
 from donjuan.face import Faces, HexFaces, SquareFaces
@@ -18,11 +18,28 @@ class Cell(ABC):
         filled: bool = False,
         door_space: Optional[DoorSpace] = None,
         contents: Optional[List[Any]] = None,
+        coordinates: Optional[Tuple[int, int]] = None,
     ):
         self.faces = faces
         self.filled = filled
         self.door_space = door_space
         self.contents = contents or []
+        self._coordinates = coordinates
+
+    def set_coordinates(self, x: int, y: int) -> None:
+        self._coordinates = (int(x), int(y))
+
+    @property
+    def coordinates(self) -> Tuple[int, int]:
+        return self._coordinates
+
+    @property
+    def x(self) -> int:
+        return self._coordinates[0]
+
+    @property
+    def y(self) -> int:
+        return self._coordinates[1]
 
     @property
     def n_sides(self) -> int:
@@ -47,10 +64,15 @@ class SquareCell(Cell):
         filled: bool = False,
         door_space: Optional[DoorSpace] = None,
         contents: Optional[List[Any]] = None,
+        coordinates: Optional[Tuple[int, int]] = None,
     ):
         faces = faces or SquareFaces()
         super().__init__(
-            faces=faces, filled=filled, door_space=door_space, contents=contents
+            faces=faces,
+            filled=filled,
+            door_space=door_space,
+            contents=contents,
+            coordinates=coordinates,
         )
 
 
@@ -72,8 +94,13 @@ class HexCell(Cell):
         filled: bool = False,
         door_space: Optional[DoorSpace] = None,
         contents: Optional[List[Any]] = None,
+        coordinates: Optional[Tuple[int, int]] = None,
     ):
         faces = faces or HexFaces()
         super().__init__(
-            faces=faces, filled=filled, door_space=door_space, contents=contents
+            faces=faces,
+            filled=filled,
+            door_space=door_space,
+            contents=contents,
+            coordinates=coordinates,
         )

--- a/donjuan/dungeon.py
+++ b/donjuan/dungeon.py
@@ -1,6 +1,7 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from donjuan.grid import Grid, SquareGrid
+from donjuan.room import Room
 
 
 class Dungeon:
@@ -9,5 +10,15 @@ class Dungeon:
         n_rows: Optional[int] = 5,
         n_cols: Optional[int] = 5,
         grid: Optional[Grid] = None,
+        rooms: Dict[str, Room] = dict(),
     ):
-        self.grid = grid if grid else SquareGrid(n_rows, n_cols)
+        self._grid = grid or SquareGrid(n_rows, n_cols)
+        self._rooms = rooms
+
+    @property
+    def grid(self) -> Grid:
+        return self._grid
+
+    @property
+    def rooms(self) -> Dict[str, Room]:
+        return self._rooms

--- a/donjuan/grid.py
+++ b/donjuan/grid.py
@@ -57,6 +57,17 @@ class Grid(ABC):
         assert isinstance(cells[0][0], cls.cell_type), msg
         return cls(len(cells), len(cells[0]), cells)
 
+    def reset_cell_coordinates(self) -> None:
+        """
+        Helper function that sets the coordinates of the cells in the grid
+        to their index values. Useful if a grid was created by
+        :meth:`from_cells`.
+        """
+        for i in range(self.n_rows):
+            for j in range(self.n_cols):
+                self.cells[i][j].set_coordinates(i, j)
+        return
+
 
 class SquareGrid(Grid):
     """

--- a/donjuan/grid.py
+++ b/donjuan/grid.py
@@ -16,7 +16,8 @@ class Grid(ABC):
         assert n_rows > 1
         assert n_cols > 1
         cells = cells or [
-            [self.cell_type() for i in range(n_cols)] for j in range(n_rows)
+            [self.cell_type(coordinates=(i, j)) for j in range(n_cols)]
+            for i in range(n_rows)
         ]
         assert len(cells) == n_rows, f"{len(cells)} vs {n_rows}"
         assert len(cells[0]) == n_cols, f"{len(cells[0])} vs {n_cols}"

--- a/donjuan/room.py
+++ b/donjuan/room.py
@@ -7,24 +7,12 @@ from donjuan import Cell
 class Room:
     def __init__(self, cells: Optional[List[List[Cell]]] = None):
         self._cells = cells or [[]]
+        for cell in chain.from_iterable(self._cells):
+            assert cell.coordinates is not None, "room cell must have coordinates"
 
     @property
     def cells(self) -> List[List[Cell]]:
         return self._cells
-
-    def grow(self, cell: Cell) -> None:
-        """
-        Add the cell to the 2D array of cells that make up this room
-        in the :attr:`cell` attribute.
-
-        .. todo:: finish implementing this
-
-        Args:
-            cell (Cell): cell to add to this room. It must have
-                :attr:`coordinates` set.
-        """
-        assert cell.coordinates, "cell must have coordinates set"
-        pass
 
     def overlaps(self, other: "Room") -> bool:
         """

--- a/donjuan/room.py
+++ b/donjuan/room.py
@@ -1,0 +1,48 @@
+from itertools import chain
+from typing import List, Optional
+
+from donjuan import Cell
+
+
+class Room:
+    def __init__(self, cells: Optional[List[List[Cell]]] = None):
+        self._cells = cells or [[]]
+
+    @property
+    def cells(self) -> List[List[Cell]]:
+        return self._cells
+
+    def grow(self, cell: Cell) -> None:
+        """
+        Add the cell to the 2D array of cells that make up this room
+        in the :attr:`cell` attribute.
+
+        .. todo:: finish implementing this
+
+        Args:
+            cell (Cell): cell to add to this room. It must have
+                :attr:`coordinates` set.
+        """
+        assert cell.coordinates, "cell must have coordinates set"
+        pass
+
+    def overlaps(self, other: "Room") -> bool:
+        """
+        Compare the cells of this room to the other room to determine
+        whether they overlap or not. Note, this algorithm is ``O(N*M)``
+        where ``N`` is the number of cells in this room and ``M`` is
+        the number of cells in the other room.
+
+        Args:
+            other (Room): other room to check against
+
+        Returns:
+            ``True`` if they overlap, ``False`` if not
+        """
+        # Loop over all of this room's cells
+        for c1 in chain.from_iterable(self.cells):
+            for c2 in chain.from_iterable(other.cells):
+                if c1.coordinates == c2.coordinates:
+                    return True
+        # No overlap
+        return False

--- a/tests/cell_test.py
+++ b/tests/cell_test.py
@@ -22,6 +22,14 @@ class SquareCellTest(TestCase):
         c = SquareCell()
         assert c.n_sides == 4
 
+    def test_coordinates(self):
+        c = SquareCell()
+        assert c.coordinates is None
+        c.set_coordinates(1, 2)
+        assert c.coordinates == (1, 2)
+        assert c.x == 1
+        assert c.y == 2
+
 
 class HexCellTest(TestCase):
     def test_smoke(self):
@@ -35,3 +43,11 @@ class HexCellTest(TestCase):
     def test_n_sides(self):
         c = HexCell()
         assert c.n_sides == 6
+
+    def test_coordinates(self):
+        c = HexCell()
+        assert c.coordinates is None
+        c.set_coordinates(1, 2)
+        assert c.coordinates == (1, 2)
+        assert c.x == 1
+        assert c.y == 2

--- a/tests/dungeon_test.py
+++ b/tests/dungeon_test.py
@@ -1,12 +1,23 @@
 from unittest import TestCase
 
-from donjuan import Dungeon, SquareGrid
+from donjuan import Dungeon, HexGrid, SquareGrid
 
 
 class DungeonTest(TestCase):
     def test_smoke(self):
         d = Dungeon()
         assert d is not None
+
+    def test_initial_attributes(self):
+        d = Dungeon()
+        assert d.rooms == {}
+
+    def test_hex_grid(self):
+        hg = HexGrid(4, 5)
+        d = Dungeon(grid=hg)
+        assert isinstance(d.grid, HexGrid)
+        assert d.grid.n_rows == 4
+        assert d.grid.n_cols == 5
 
     def test_pass_dimensions(self):
         d = Dungeon(n_rows=4, n_cols=5)

--- a/tests/grid_test.py
+++ b/tests/grid_test.py
@@ -20,6 +20,12 @@ class SquareGridTest(TestCase):
         assert sg.n_rows == 5
         assert isinstance(sg.cells[0][0], SquareCell)
 
+    def test_cell_coordinates(self):
+        sg = SquareGrid(5, 4)
+        for i in range(sg.n_rows):
+            for j in range(sg.n_cols):
+                assert sg.cells[i][j].coordinates == (i, j)
+
     def test_get_filled_grid(self):
         sg = SquareGrid(5, 5)
         fg = sg.get_filled_grid()

--- a/tests/grid_test.py
+++ b/tests/grid_test.py
@@ -27,22 +27,33 @@ class SquareGridTest(TestCase):
                 assert sg.cells[i][j].coordinates == (i, j)
 
     def test_get_filled_grid(self):
-        sg = SquareGrid(5, 5)
+        sg = SquareGrid(5, 4)
         fg = sg.get_filled_grid()
         assert all(fg)
 
     def test_get_filled_grid_some_unfilled(self):
-        sg = SquareGrid(5, 5)
+        sg = SquareGrid(5, 4)
         for i in range(5):
             sg.cells[i][3].filled = True
         fg = sg.get_filled_grid()
         for i in range(5):
-            for j in range(5):
+            for j in range(4):
                 assert fg[i][j] == sg.cells[i][j].filled, (i, j)
                 if j != 3:
                     assert not fg[i][j], (i, j)
                 else:
                     assert fg[i][j], (i, j)
+
+    def test_reset_cell_coordinates(self):
+        cells = [[SquareCell() for i in range(4)] for j in range(5)]
+        sg = SquareGrid.from_cells(cells)
+        for i in range(sg.n_rows):
+            for j in range(sg.n_cols):
+                assert sg.cells[i][j].coordinates is None
+        sg.reset_cell_coordinates()
+        for i in range(sg.n_rows):
+            for j in range(sg.n_cols):
+                assert sg.cells[i][j].coordinates == (i, j)
 
 
 class HexGridTest(TestCase):

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
-from donjuan import Room
+import pytest
+
+from donjuan import Room, SquareCell
 
 
 class RoomTest(TestCase):
@@ -8,3 +10,8 @@ class RoomTest(TestCase):
         r = Room()
         assert r is not None
         assert r.cells == [[]]
+
+    def test_assert_cell_coords(self):
+        c = SquareCell()
+        with pytest.raises(AssertionError):
+            Room(cells=[[c]])

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from unittest import TestCase
 
 import pytest
@@ -15,3 +16,19 @@ class RoomTest(TestCase):
         c = SquareCell()
         with pytest.raises(AssertionError):
             Room(cells=[[c]])
+
+    def test_overlaps(self):
+        cs = [[SquareCell(coordinates=(i, j)) for j in range(5)] for i in range(4)]
+        r1 = Room(cs)
+        r2 = Room(deepcopy(cs))
+        assert r1.overlaps(r2)
+
+    def test_no_overlap(self):
+        cs = [[SquareCell(coordinates=(i, j)) for j in range(5)] for i in range(4)]
+        r1 = Room(cs)
+        cs2 = deepcopy(cs)
+        for i in range(len(cs)):
+            for j in range(len(cs[0])):
+                cs2[i][j].set_coordinates(100 + i, j)
+        r2 = Room(cs2)
+        assert not r1.overlaps(r2)

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from donjuan import Room
+
+
+class RoomTest(TestCase):
+    def test_smoke(self):
+        r = Room()
+        assert r is not None
+        assert r.cells == [[]]


### PR DESCRIPTION
Closes #25 

This PR implements the `Room` class and makes a significant change to the `Cell` class by adding coordinates to it.

Specifically this PR:
- create the `Room` class with tests, which is just a collection of rooms (very similar to a `Grid`)
- implements the `Room.overlaps` function that checks if one room overlaps with another based on the rooms' cell's coordinates
- adds the `coordinates` attribute to the `Cell` class, which must be a pair of integers (for now)
- adds a function to `Grid` to set the coordinates of the cells in the grid to default values, so that if the grid was created with `from_cells` and the `Cell` objects didn't have coordinates set, this method resets them
- adds a `rooms` argument to the `Dungeon` class
- privatizes the `rooms` and `grid` attributes of the `Dungeon` class