### PR TITLE
Edges cleanup

### DIFF
--- a/donjuan/dungeon.py
+++ b/donjuan/dungeon.py
@@ -61,11 +61,13 @@ class Dungeon:
 
     def emplace_room(self, room: Room) -> None:
         """
-        Replace the cells in the :attr:`grid` with the cells of the `Room`.
+        Replace the cells in the :attr:`grid` with the cells of the `Room`,
+        and automatically link them with the `Edge`s in the `Grid`.
 
         Args:
             room (Room): room to emplace in the :attr:`grid`
         """
         for cell in room.cells:
             self.grid.cells[cell.y][cell.x] = cell
+        self.grid.link_edges_to_cells()
         return

--- a/donjuan/grid.py
+++ b/donjuan/grid.py
@@ -44,7 +44,6 @@ class Grid(ABC):
         self.check_edges(edges)
         self._edges = edges
         self.link_edges_to_cells()
-        self.link_cells_to_edges()
 
     def get_filled_grid(self) -> List[List[bool]]:
         """
@@ -132,6 +131,7 @@ class Grid(ABC):
                     self.edges[k][i][j].set_cell2(
                         self.cells[i][j] if j < self.n_cols else None
                     )
+        self.link_cells_to_edges()
         return
 
     @abstractmethod


### PR DESCRIPTION
This PR:

- moves `Grid.link_cells_to_edges` to being called from within `Grid.link_edges_to_cells` so that it is never forgotten
- fixes a bug in `Dungeon.emplace_room` where edges and cells weren't being linked